### PR TITLE
Add Hugging Face integration

### DIFF
--- a/models_cross.py
+++ b/models_cross.py
@@ -328,15 +328,14 @@ class CrossMAE(MaskedAutoencoderViT, PyTorchModelHubMixin):
 
 # create model
 config = dict(patch_size=16, embed_dim=384, depth=12, num_heads=6,
-        decoder_embed_dim=256, decoder_num_heads=8,
-        mlp_ratio=4, norm_layer=partial(nn.LayerNorm, eps=1e-6))
+        decoder_embed_dim=256, decoder_num_heads=8, mlp_ratio=4)
 
 model = CrossMAE(config)
 
 # load weights
 state_dict = torch.hub.load_state_dict_from_url("https://huggingface.co/longlian/CrossMAE/resolve/main/vits-mr0.75-kmr0.75-dd12/imagenet-mae-cross-vits-pretrain-wfm-mr0.75-kmr0.75-dd12-ep800-ui.pth?download=true",
                                                 map_location="cpu")
-model.load_state_dict(state_dict["model"])
+model.load_state_dict(state_dict["model"], strict=False)
 
 # save locally
 # model.save_pretrained("./crossmae-small", config=config)


### PR DESCRIPTION
Hi @TonyLianLong and team!

Thanks for this nice work. I wrote a quick PoC to showcase that you can easily have integration so that you can automatically load the various CrossMAE models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```
from models_cross import CrossMAE

model = CrossMAE.from_pretrained("nielsr/crossmae-small-patch16")
```
The corresponding model is here for now: https://huggingface.co/nielsr/crossmae-small-patch16. We could move all checkpoints to separate repos on your account on https://hf.co if you're interested.

This will make sure you can track download numbers for each individual checkpoint!

Would you be interested in this integration?

Kind regards,

Niels